### PR TITLE
Add plugin to change symlink resolve method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Dev Env

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+SCRIPT_LOCATION="$(dirname $(readlink -f "$0"))"
+HBT_REPO="$SCRIPT_LOCATION/../huronOS-build-tools"
+
+clean() {
+    echo # To handle ctrl+c line
+    echo "Cleaning dev environment"
+
+    unlink "./docs"
+    rm -f "./docs"
+    mv docs.bak docs
+
+    sed -i '/docs/d' .gitignore
+    git update-index --no-assume-unchanged ".gitignore"
+
+    pushd "docs/"
+    git ls-files | tr '\n' ' ' | xargs git update-index --no-assume-unchanged
+    popd
+
+    echo "Successfully cleaned dev environment"
+    exit
+}
+
+setup() {
+    echo "Downloading huronOS-build-tools for documentation source"
+    if ! git clone https://github.com/equetzal/huronOS-build-tools "$HBT_REPO" 2>/dev/null && [ -d "${HBT_REPO}" ]; then
+        echo "huronOS-build-tools repository already present!"
+    fi
+
+    echo "Installing dependencies"
+    yarn install
+
+    echo "Hiding local docs/ directory"
+    echo "docs" >>.gitignore
+    echo "docs/" >>.gitignore
+    echo "docs.bak/" >>.gitignore
+    pushd "docs/"
+    git ls-files | tr '\n' ' ' | xargs git update-index --assume-unchanged
+    popd
+    mv docs docs.bak
+    git update-index --assume-unchanged ".gitignore"
+
+    echo "Symlinking huronOS-build-tools/docs with huronOS-website/docs"
+    ln -sf "$HBT_REPO/docs" "./docs"
+
+    echo "Stating Docusaurus dev server"
+    trap clean INT
+    yarn start
+}
+
+setup

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,6 +3,7 @@
 
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const path = require("path")
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -127,6 +128,8 @@ const config = {
 				darkTheme: darkCodeTheme,
 			},
 		}),
+
+		plugins: [require.resolve(path.join(__dirname, '/plugins/symlink-resolver'))]
 };
 
 module.exports = config;

--- a/plugins/symlink-resolver/index.js
+++ b/plugins/symlink-resolver/index.js
@@ -1,0 +1,12 @@
+module.exports = (context, options) => {
+    return {
+      name: 'symlink-resolver',
+      configureWebpack(config, isServer, utils, content) {    
+        return {
+          resolve: {
+            symlinks: false,
+          },
+        };
+      },
+    };
+  };

--- a/plugins/symlink-resolver/package.json
+++ b/plugins/symlink-resolver/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "symlink-resolver",
+    "version": "0.0.1",
+    "private": true
+  }
+  


### PR DESCRIPTION
## Description
This PR enables developers to setup the huronOS-build-tools repository to work in conjuntion with this repo by symlinking the `huronOS-build-tools/docs` directory to the `huronOS-website/docs` repository while developing. 

Executing `.dev-start.sh` will hide the current `docs/` directory and use the `huronOS-build-tools/docs` with docusaurus. After ctrl+c the script will restore the previous state on git.

This PR solves #2 