### PR TITLE
Adding script to remove TODO files

### DIFF
--- a/.github/scripts/quit-todo.sh
+++ b/.github/scripts/quit-todo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#	quit-todo.sh
+#	Script to detele all the files on the huronOS website documentation
+#   that contains a TODO string on it.
+#   This script allows to remove unfinished work on the project before
+#   deploying in production website.
+#
+#	Copyright (C) 2022, huronOS Project:
+#		<http://huronos.org>
+#
+#	Licensed under the GNU GPL Version 2
+#		<http://www.gnu.org/licenses/gpl-2.0.html>
+#
+#	Authors:
+#		Enya Quetzalli <equetzal@huronos.org>
+
+# Change to the website/docs directory
+cd docs || exit
+
+# Find and delete markdown files containing "TODO"
+find . -type f -name "*.md" -exec grep -q "TODO" {} \; -exec rm {} \;


### PR DESCRIPTION
This PR adds an small script to remove all the files in the docs/ directory that contain a "TODO" string. This can be used to deploy to production without including the TODO files. 
With this, including a TODO in any doc file will make it non-public on huronos.org but visible in staging.huronos.org

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/huronOS/website/pull/5).
* #6
* __->__ #5