### PR TITLE
Ommit TODO inside codeblocks so that we can document

### DIFF
--- a/.github/scripts/quit-todo.sh
+++ b/.github/scripts/quit-todo.sh
@@ -18,5 +18,24 @@
 # Change to the website/docs directory
 cd docs || exit
 
-# Find and delete markdown files containing "TODO"
-find . -type f -name "*.md" -exec grep -q "TODO" {} \; -exec rm {} \;
+# Check if "TODO" is present outside code blocks
+has_todo() {
+    local file="$1"
+
+    # Remove code blocks and inline code using sed
+    local content
+    content=$(sed -e '/```/,/```/d' -e 's/`[^`]*`//g' "$file")
+
+    # Check for "TODO" outside code blocks and inline code
+    if [[ $content == *TODO* ]]; then
+        return 0 # Has TODO
+    else
+        return 1 # Does not have TODO
+    fi
+}
+
+while IFS= read -r file; do
+    if has_todo "$file"; then
+        echo "File $file have TODO"
+    fi
+done < <(find . -type f -name "*.md")

--- a/docs/docs
+++ b/docs/docs
@@ -1,0 +1,1 @@
+/Users/quetzalli/src/website/../huronOS-build-tools/docs


### PR DESCRIPTION
## Problem
Currently, anything that contains a TODO substring is removed from Prod deploy. This behavior makes difficult to actually document this functionality. 

## Proposed solution
Allow all TODO that is inside simple backsticks or triple backsticks will be ommited from the removal.
````markdown
`TODO`

```
TODO
```
````