### PR TITLE
Remove bad argument in installation guide

### DIFF
--- a/docs/usage/how-to-install.md
+++ b/docs/usage/how-to-install.md
@@ -35,7 +35,7 @@ sidebar_position: 1
    ```
 - **On Arch Linux:**  
    ```bash
-   pacman -S install squashfs-tools parted psmisc e2fsprogs dosfstools perl
+   pacman -S squashfs-tools parted psmisc e2fsprogs dosfstools perl
    ```
 
 ### Process


### PR DESCRIPTION
`install` is not an argument nor a package in pacman package manager